### PR TITLE
Changed encoding of default db from 'unicode' to 'UTF8'

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -16,7 +16,7 @@
 #
 default: &default
   adapter: postgresql
-  encoding: unicode
+  encoding: UTF8
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>


### PR DESCRIPTION
### Notes

Often times `unicode` is confused for being synonymous with `UTF8`, but using these terms interchangeably [doesn't make sense](https://stackoverflow.com/a/13212528).

I replaced the encoding variable in the default database configuration to `UTF8` to avoid confusion between those two terms.

Postgres accepts an encoding value of `UTF8` for its databases, which is also aliased to `unicode` [according to the docs](https://www.postgresql.org/docs/9.0/static/multibyte.html#CHARSET-TABLE), so the functionality is identical.

### Testing
* Created databases with the previous and new `encoding` value by using `$ rake db:drop db:create db:migrate`
* Checked the encoding using the previous and new value. Both times, the following was printed:
```
 server_encoding
-----------------
 UTF8
(1 row)
```