### PR TITLE
Dynamically load associations to improve performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'rack-cors'
 
 gem 'acts_as_list'
 gem 'graphql'
+gem 'graphql-batch'
 gem 'pundit'
 gem 'validates_timeliness'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,9 @@ GEM
     graphiql-rails (1.4.5)
       rails
     graphql (1.7.4)
+    graphql-batch (0.3.5)
+      graphql (>= 0.8, < 2)
+      promise.rb (~> 0.7.2)
     guard (2.14.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -124,6 +127,7 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     pg (0.21.0)
+    promise.rb (0.7.4)
     pry (0.11.1)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -237,6 +241,7 @@ DEPENDENCIES
   faker
   graphiql-rails
   graphql
+  graphql-batch
   guard-rspec
   letter_opener
   listen (>= 3.0.5, < 3.2)

--- a/app/graphql/record_loader.rb
+++ b/app/graphql/record_loader.rb
@@ -1,0 +1,10 @@
+class RecordLoader < GraphQL::Batch::Loader
+  def initialize(model)
+    @model = model
+  end
+
+  def perform(ids)
+    @model.where(id: ids).each { |record| fulfill(record.id, record) }
+    ids.each { |id| fulfill(id, nil) unless fulfilled?(id) }
+  end
+end

--- a/app/graphql/records_api_schema.rb
+++ b/app/graphql/records_api_schema.rb
@@ -2,6 +2,8 @@ RecordsApiSchema = GraphQL::Schema.define do
   mutation Types::MutationType
   query Types::QueryType
 
+  use GraphQL::Batch
+
   rescue_from Pundit::NotAuthorizedError, &:message
 
   resolve_type(lambda do |type, _obj, _ctx|

--- a/app/graphql/types/challenge_type.rb
+++ b/app/graphql/types/challenge_type.rb
@@ -15,7 +15,9 @@ module Types
     field :position, !types.Int
 
     ## Belongs to associations
-    field :recordBook, !RecordBookType, property: :record_book
+    field :recordBook, !RecordBookType do
+      resolve ->(obj, _args, _ctx) { RecordLoader.for(RecordBook).load obj.record_book_id }
+    end
 
     ## Has many associations
     field :completions, types[!CompletionType]

--- a/app/graphql/types/completion_type.rb
+++ b/app/graphql/types/completion_type.rb
@@ -13,8 +13,12 @@ module Types
     field :status, !Enums::CompletionStatusEnum
 
     ## Belongs to associations
-    field :challenge, !ChallengeType
-    field :participation, !ParticipationType
+    field :challenge, !ChallengeType do
+      resolve ->(obj, _args, _ctx) { RecordLoader.for(Challenge).load obj.challenge_id }
+    end
+    field :participation, !ParticipationType do
+      resolve ->(obj, _args, _ctx) { RecordLoader.for(Participation).load obj.participation_id }
+    end
 
     ## Has one associations
     field :record_book, !RecordBookType

--- a/app/graphql/types/participation_type.rb
+++ b/app/graphql/types/participation_type.rb
@@ -10,9 +10,15 @@ module Types
     field :teamId, types.Int, property: :team_id
 
     ## Belongs to associations
-    field :recordBook, !RecordBookType, property: :record_book
-    field :team, TeamType
-    field :user, !UserType
+    field :recordBook, !RecordBookType do
+      resolve ->(obj, _args, _ctx) { RecordLoader.for(RecordBook).load obj.record_book_id }
+    end
+    field :team, TeamType do
+      resolve ->(obj, _args, _ctx) { RecordLoader.for(Team).load obj.team_id }
+    end
+    field :user, !UserType do
+      resolve ->(obj, _args, _ctx) { RecordLoader.for(User).load obj.user_id }
+    end
 
     ## Has many associations
     field :completions, types[!CompletionType]


### PR DESCRIPTION
This will prevent n+1 SQL queries in our responses.